### PR TITLE
docs: add platform-specific install notes for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The CLI distributes as a self-contained, statically linked fat binary. No comple
 curl -fsSL https://raw.githubusercontent.com/GyaneshSamanta/cue/main/scripts/install.sh | bash
 ```
 
+> **Note for Arch Linux Users:** The `install.sh` script is fully compatible with Arch Linux. For optimal compatibility with future AUR packaging and dependencies, ensure you have the base development tools installed via `sudo pacman -S base-devel`.
+
 </details>
 
 <details>


### PR DESCRIPTION
Fixes #2

Added a brief note to the Linux/macOS installation section confirming Arch Linux compatibility for `install.sh` and mentioning `pacman` dependencies (`base-devel`) to help Arch users.