### PR TITLE
Fix releases + add Gemma/local-model support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.x"
+          check-latest: true
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to (re)build and attach assets to (e.g. v2.1.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            ext: ""
+          - goos: linux
+            goarch: arm64
+            ext: ""
+          - goos: darwin
+            goarch: amd64
+            ext: ""
+          - goos: darwin
+            goarch: arm64
+            ext: ""
+          - goos: windows
+            goarch: amd64
+            ext: ".exe"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.x"
+          check-latest: true
+
+      - name: Resolve version
+        id: ver
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: |
+          OUT="cue-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}"
+          go build -trimpath \
+            -ldflags "-s -w -X main.Version=${{ steps.ver.outputs.version }} -X main.BuildDate=${{ steps.ver.outputs.build_date }}" \
+            -o "dist/${OUT}" .
+          (cd dist && sha256sum "${OUT}" > "${OUT}.sha256")
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cue-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish release assets
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Resolve tag
+        id: ver
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.ver.outputs.tag }}"
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes
+          fi
+          gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber dist/*

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 <br>
 
 <div align="center">
-  <h2>📺 Welcome to v2.0</h2>
+  <h2>📺 Welcome to v2.2</h2>
   <img src="docs/assets/onboarding_demo.gif" alt="Onboarding Demo" width="900" style="border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,0.5);">
   <br><br>
   <h3>🏪 Environment Store Management</h3>
@@ -219,6 +219,27 @@ se := ui.NewStructuredError(
 )
 ui.HandleError(se)
 ```
+
+---
+
+## 📋 Changelog
+
+### v2.2.0 — May 2026
+
+**New**
+- **`cue model` command** — the `internal/model` package was wired up and is now a first-class CLI feature. Run `cue model --help` to see all subcommands.
+- **Google Gemma 3 support** — `cue model gemma [1b|4b|12b|27b]` installs Google Gemma via Ollama in one command. Hardware-aware `cue model recommend` now includes all four Gemma sizes.
+- **`cue toolkit` command** — install, upgrade, remove, and inspect developer tools with automatic version-manager bootstrapping (e.g. `cue toolkit install node`). Closes the loop from `cue doctor fix --all`, which had been suggesting `cue toolkit install <tool>` when the command didn't yet exist.
+- **Release pipeline** — added `.github/workflows/release.yml` that cross-compiles for linux/darwin/windows × amd64/arm64 and uploads binaries to GitHub Releases on every version tag. **This is what was causing the broken `install.sh` / `install.ps1`** — prior releases had no binary assets.
+- **CI pipeline** — added `.github/workflows/ci.yml` for build / vet / test checks on every PR.
+
+**Fixed**
+- `install.sh` and `install.ps1` now fail with a clear actionable error if no release is found, instead of silently downloading nothing.
+- Both scripts accept a `CUE_VERSION=vX.Y.Z` / `$env:CUE_VERSION` env var to pin to a specific release.
+- `cue model list/pull/gemma` now prints a friendly install hint (brew / curl / winget) if Ollama is missing, instead of an opaque exec error.
+
+**Improved**
+- README install section: explicit Arch Linux guidance, versioned-install snippets, build-from-source instructions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,14 +56,23 @@ Modern application development requires immense cognitive overhead. Should you u
 The CLI distributes as a self-contained, statically linked fat binary. No complex Node/Python/Ruby dependencies are strictly required to run it!
 
 <details>
-<summary><b>🐧 Linux / macOS</b></summary>
+<summary><b>🐧 Linux / macOS (incl. Arch Linux support)</b></summary>
 <br>
 
+**One-liner install (Ubuntu / Debian / Arch / macOS):**
 ```bash
 curl -fsSL https://raw.githubusercontent.com/GyaneshSamanta/cue/main/scripts/install.sh | bash
 ```
 
-> **Note for Arch Linux Users:** The `install.sh` script is fully compatible with Arch Linux. For optimal compatibility with future AUR packaging and dependencies, ensure you have the base development tools installed via `sudo pacman -S base-devel`.
+To pin a specific version:
+```bash
+curl -fsSL https://raw.githubusercontent.com/GyaneshSamanta/cue/main/scripts/install.sh | CUE_VERSION=v2.1.0 bash
+```
+
+**Arch Linux specifics:** The `install.sh` script works directly on Arch. We recommend having `base-devel`, `curl`, and `sudo` ready (`sudo pacman -S --needed base-devel curl`).
+
+> [!TIP]
+> **AUR packaging:** AUR support (`cue-bin`) is currently in development. For now, the direct install is the recommended path.
 
 </details>
 
@@ -73,6 +82,25 @@ curl -fsSL https://raw.githubusercontent.com/GyaneshSamanta/cue/main/scripts/ins
 
 ```powershell
 iwr https://raw.githubusercontent.com/GyaneshSamanta/cue/main/scripts/install.ps1 -useb | iex
+```
+
+To pin a specific version:
+```powershell
+$env:CUE_VERSION = 'v2.1.0'; iwr https://raw.githubusercontent.com/GyaneshSamanta/cue/main/scripts/install.ps1 -useb | iex
+```
+
+</details>
+
+<details>
+<summary><b>🛠 Build from source</b></summary>
+<br>
+
+Requires Go 1.26+.
+
+```bash
+git clone https://github.com/GyaneshSamanta/cue && cd cue
+go build -o cue .
+./cue --version
 ```
 
 </details>
@@ -115,6 +143,33 @@ cue claude-code install
 During installation, it offers multiple execution engines:
 1. **API Mode:** Sends code direct to the cloud. Best for reasoning.
 2. **Local Mode (Ollama):** Purely local. Pulls models down through `ollama` and proxies them securely. **This implementation is 100% free and extremely private.**
+
+---
+
+## 🧠 Local Models (Ollama, Gemma & friends)
+
+Run open-weight models on your own machine, then point Claude Code at them. Cue takes care of pulling, switching, and benchmarking.
+
+```bash
+cue model recommend           # hardware-aware suggestions for your laptop
+cue model gemma               # one-shot install of Google Gemma 3 (4B default)
+cue model gemma 12b           # bigger Gemma for stronger quality
+cue model pull qwen2.5-coder:7b
+cue model use gemma3:4b       # set as the default for Claude Code
+cue model list                # see what's installed
+cue model benchmark gemma3:4b # quick speed test
+```
+
+**Gemma sizes** at a glance:
+
+| Tag | Size | Best for |
+| :--- | :--- | :--- |
+| `gemma3:1b` | ~0.8 GB | Tiny laptops, instant load |
+| `gemma3:4b` | ~3.3 GB | Default — strong general use on 8 GB+ RAM |
+| `gemma3:12b` | ~8.1 GB | High quality on 16 GB RAM / 12 GB VRAM |
+| `gemma3:27b` | ~17 GB  | Best local quality on 32 GB RAM / 24 GB VRAM |
+
+> Cue requires [Ollama](https://ollama.com/download) for local models. Run `cue model gemma` and Cue will tell you exactly how to install it if it's missing.
 
 ---
 

--- a/cmd/model.go
+++ b/cmd/model.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/GyaneshSamanta/cue/internal/model"
+	"github.com/GyaneshSamanta/cue/internal/ui"
+)
+
+var modelCmd = &cobra.Command{
+	Use:   "model",
+	Short: "Manage local AI models (Ollama, Gemma, etc.)",
+	Long: `Manage local AI models served by Ollama, including Google Gemma.
+
+Cue treats Ollama as the canonical local-model runtime. Use this command
+to pull models, set the active model for Claude Code, benchmark inference
+speed, or get hardware-aware recommendations (including Gemma sizes).`,
+}
+
+var modelListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List installed local models",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return model.ListModels()
+	},
+}
+
+var modelPullCmd = &cobra.Command{
+	Use:   "pull <name>",
+	Short: "Download a model (e.g. gemma3:4b, llama3.1:8b)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return model.PullModel(args[0])
+	},
+}
+
+var modelRemoveCmd = &cobra.Command{
+	Use:   "remove <name>",
+	Short: "Remove a downloaded model",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return model.RemoveModel(args[0])
+	},
+}
+
+var modelUseCmd = &cobra.Command{
+	Use:   "use <name>",
+	Short: "Set the default model used by Claude Code",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return model.UseModel(args[0])
+	},
+}
+
+var modelRecommendCmd = &cobra.Command{
+	Use:   "recommend",
+	Short: "Suggest models based on detected hardware",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return model.Recommend()
+	},
+}
+
+var modelBenchmarkCmd = &cobra.Command{
+	Use:   "benchmark [name]",
+	Short: "Run a quick inference speed test",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := ""
+		if len(args) == 1 {
+			name = args[0]
+		}
+		return model.Benchmark(name)
+	},
+}
+
+var modelSearchCmd = &cobra.Command{
+	Use:   "search <query>",
+	Short: "Search the Ollama registry",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return model.Search(args[0])
+	},
+}
+
+var modelGemmaCmd = &cobra.Command{
+	Use:   "gemma [size]",
+	Short: "Quick-install Google Gemma (sizes: 1b, 4b, 12b, 27b — default 4b)",
+	Long: `Quick-install Google Gemma 3 via Ollama.
+
+Examples:
+  cue model gemma          # installs gemma3:4b (good default for 16GB RAM)
+  cue model gemma 1b       # tiny — fits low-RAM laptops
+  cue model gemma 12b      # quality — needs ~16GB RAM or 12GB VRAM
+  cue model gemma 27b      # best — needs ~32GB RAM or 24GB VRAM
+
+After install, run 'cue model use gemma3:<size>' to make it the default
+for Claude Code.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		size := "4b"
+		if len(args) == 1 {
+			size = args[0]
+		}
+		valid := map[string]bool{"1b": true, "4b": true, "12b": true, "27b": true}
+		if !valid[size] {
+			ui.PrintWarning("Unknown Gemma size '" + size + "'. Supported: 1b, 4b, 12b, 27b. Proceeding anyway.")
+		}
+		tag := "gemma3:" + size
+		if err := model.EnsureOllama(); err != nil {
+			return err
+		}
+		return model.PullModel(tag)
+	},
+}
+
+func init() {
+	modelCmd.AddCommand(modelListCmd, modelPullCmd, modelRemoveCmd, modelUseCmd,
+		modelRecommendCmd, modelBenchmarkCmd, modelSearchCmd, modelGemmaCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,6 +120,7 @@ func init() {
 	rootCmd.AddCommand(updateCmd)
 	rootCmd.AddCommand(versionMgrCmd)
 	rootCmd.AddCommand(doctorCmd)
+	rootCmd.AddCommand(modelCmd)
 }
 
 // Execute runs the root command.

--- a/internal/model/manager.go
+++ b/internal/model/manager.go
@@ -12,8 +12,25 @@ import (
 	"github.com/GyaneshSamanta/cue/internal/ui"
 )
 
+// EnsureOllama verifies that the Ollama runtime is installed and reachable.
+// It returns a helpful, actionable error if not — rather than letting an
+// opaque exec failure bubble up.
+func EnsureOllama() error {
+	if _, err := exec.LookPath("ollama"); err != nil {
+		ui.PrintWarning("Ollama is not installed. Install it from https://ollama.com/download")
+		ui.PrintDim("  macOS:    brew install ollama")
+		ui.PrintDim("  Linux:    curl -fsSL https://ollama.com/install.sh | sh")
+		ui.PrintDim("  Windows:  winget install Ollama.Ollama")
+		return fmt.Errorf("ollama not found in PATH")
+	}
+	return nil
+}
+
 // ListModels shows all Ollama models.
 func ListModels() error {
+	if err := EnsureOllama(); err != nil {
+		return err
+	}
 	out, err := exec.Command("ollama", "list").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("ollama not running or not installed: %w", err)
@@ -82,6 +99,10 @@ func Recommend() error {
 		{"Reasoning", "deepseek-r1:8b", "5.2 GB", "Strong multi-step reasoning", ramGB >= 12},
 		{"Reasoning (large)", "deepseek-r1:14b", "9.1 GB", "Best reasoning under 15B", ramGB >= 24},
 		{"General", "llama3.1:8b", "4.7 GB", "Versatile general model", ramGB >= 12},
+		{"Gemma (tiny)", "gemma3:1b", "0.8 GB", "Google Gemma 3 — runs anywhere", true},
+		{"Gemma (default)", "gemma3:4b", "3.3 GB", "Google Gemma 3 — strong general use", ramGB >= 8},
+		{"Gemma (quality)", "gemma3:12b", "8.1 GB", "Google Gemma 3 — high quality", ramGB >= 16 || vramGB >= 12},
+		{"Gemma (large)", "gemma3:27b", "17 GB", "Google Gemma 3 — best quality", ramGB >= 32 || vramGB >= 24},
 	}
 
 	fmt.Println("  Recommendations:")

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -27,14 +27,19 @@ $Arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "386" }
 Write-Ok "Detected: windows/$Arch"
 
 # Get latest version
-Write-Step "Fetching latest version..."
-try {
-    $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
-    $Version = $Release.tag_name -replace '^v', ''
-    Write-Ok "Latest version: v$Version"
-} catch {
-    $Version = "1.0.0"
-    Write-Warn "Could not fetch latest version, using v$Version"
+if ($env:CUE_VERSION) {
+    $Version = $env:CUE_VERSION -replace '^v', ''
+    Write-Ok "Using requested version: v$Version"
+} else {
+    Write-Step "Fetching latest version..."
+    try {
+        $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
+        $Version = $Release.tag_name -replace '^v', ''
+        Write-Ok "Latest version: v$Version"
+    } catch {
+        Write-Err "Could not fetch latest release. Set `$env:CUE_VERSION = 'vX.Y.Z' to install a specific version, or download from https://github.com/$Repo/releases"
+        exit 1
+    }
 }
 
 # Download

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,10 +43,15 @@ detect_platform() {
 
 # Get latest release version
 get_latest_version() {
-    VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"v?([^"]+)".*/\1/')
+    if [ -n "${CUE_VERSION:-}" ]; then
+        VERSION="${CUE_VERSION#v}"
+        print_ok "Using requested version: v${VERSION}"
+        return
+    fi
+    VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | head -n1 | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v?([^"]+)".*/\1/')
     if [ -z "$VERSION" ]; then
-        VERSION="1.0.0"
-        print_warn "Could not fetch latest version, using v${VERSION}"
+        print_err "Could not fetch latest release. Set CUE_VERSION=vX.Y.Z to install a specific version, or download from https://github.com/${REPO}/releases"
+        exit 1
     fi
     print_ok "Latest version: v${VERSION}"
 }


### PR DESCRIPTION
## Summary
- **Fixes broken download** (item #1 in todo). Root cause: latest release v2.1.0 has no binary assets, and v2.0.0 only has an old `gyanesh-help.exe`, while `install.sh` / `install.ps1` fetch `cue-{os}-{arch}`. Added `.github/workflows/release.yml` to build and upload the correct assets on every tag (and via `workflow_dispatch` to backfill existing tags).
- **Adds Google Gemma support** (item #2). `internal/model` was orphaned — no `cmd/model.go`, never registered. Wired it up and added a quick-install `cue model gemma [1b|4b|12b|27b]` command, plus Gemma entries in the hardware-aware recommender.
- **Hardens install scripts**: `CUE_VERSION` pin, fail loudly when no release is found, more robust `tag_name` parsing.
- **Adds CI** (`build / vet / test` on PRs).
- **README**: rewrites install section (versioned install, build-from-source, rolled-in #7 Arch notes), adds a Local Models section with Gemma sizing table.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green
- [x] `cue model --help` lists all subcommands including `gemma`
- [ ] After merge: cut a fresh tag (e.g. `v2.1.1`) — release workflow should attach `cue-linux-amd64`, `cue-linux-arm64`, `cue-darwin-amd64`, `cue-darwin-arm64`, `cue-windows-amd64.exe` (with `.sha256` companions). Then verify `install.sh` end-to-end on a clean machine.
- [ ] Or: trigger the workflow manually via `Actions → Release → Run workflow` with `tag=v2.1.0` to backfill the existing release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)